### PR TITLE
Hide modules that fail to fetch posters

### DIFF
--- a/Move_list 2.js
+++ b/Move_list 2.js
@@ -919,7 +919,9 @@ async function loadTodayGlobalMedia(params = {}) {
       params: { language, api_key: API_KEY }
     });
     const genreMap = await fetchTmdbGenres();
-    return res.results.map(item => formatTmdbItem(item, genreMap.movie));
+    return res.results
+      .map(item => formatTmdbItem(item, genreMap.movie))
+      .filter(item => item.posterPath); // 新增过滤
   } catch (error) {
     console.error("Error fetching trending media:", error);
     return [];
@@ -934,7 +936,9 @@ async function loadWeekGlobalMovies(params = {}) {
       params: { language, api_key: API_KEY }
     });
     const genreMap = await fetchTmdbGenres();
-    return res.results.map(item => formatTmdbItem(item, genreMap.movie));
+    return res.results
+      .map(item => formatTmdbItem(item, genreMap.movie))
+      .filter(item => item.posterPath); // 新增过滤
   } catch (error) {
     console.error("Error fetching weekly global movies:", error);
     return [];
@@ -981,7 +985,9 @@ async function tmdbTopRated(params = {}) {
         params: { language, page, api_key: API_KEY }
       });
       const genreMap = await fetchTmdbGenres();
-      return res.results.map(item => formatTmdbItem(item, genreMap[type]));
+      return res.results
+        .map(item => formatTmdbItem(item, genreMap[type]))
+        .filter(item => item.posterPath); // 新增过滤
     } else {
       const endpoint = type === "movie" ? "/discover/movie" : "/discover/tv";
       const res = await Widget.tmdb.get(endpoint, {
@@ -993,7 +999,9 @@ async function tmdbTopRated(params = {}) {
         }
       });
       const genreMap = await fetchTmdbGenres();
-      return res.results.map(item => formatTmdbItem(item, genreMap[type]));
+      return res.results
+        .map(item => formatTmdbItem(item, genreMap[type]))
+        .filter(item => item.posterPath); // 新增过滤
     }
   } catch (error) {
     console.error("Error fetching top rated:", error);
@@ -1116,7 +1124,7 @@ async function imdbPopularContent(params = {}) {
       formattedItem.type = "imdb";
       formattedItem.source = "IMDB高分精选";
       return formattedItem;
-    });
+    }).filter(item => item.posterPath); // 新增过滤
   } catch (error) {
     console.error("Error fetching IMDB popular content:", error);
     return [];
@@ -1187,7 +1195,7 @@ async function imdbYearlySelection(params = {}) {
       formattedItem.source = `IMDB ${primary_release_year || '全年'}精选`;
       formattedItem.year = primary_release_year || new Date(item.release_date || item.first_air_date).getFullYear();
       return formattedItem;
-    });
+    }).filter(item => item.posterPath); // 新增过滤
   } catch (error) {
     console.error("Error fetching IMDB yearly selection:", error);
     return [];
@@ -1246,7 +1254,7 @@ async function bangumiHotNewAnime(params = {}) {
       formattedItem.seasonYear = season_year;
       formattedItem.isNewAnime = true;
       return formattedItem;
-    });
+    }).filter(item => item.posterPath); // 新增过滤
   } catch (error) {
     console.error("Error fetching Bangumi hot new anime:", error);
     return [];
@@ -1325,7 +1333,7 @@ async function bangumiRankingList(params = {}) {
       formattedItem.source = `Bangumi${getRankingTypeName(ranking_type)}`;
       formattedItem.rankingType = ranking_type;
       return formattedItem;
-    });
+    }).filter(item => item.posterPath); // 新增过滤
   } catch (error) {
     console.error("Error fetching Bangumi ranking list:", error);
     return [];
@@ -1397,7 +1405,7 @@ async function tmdbPopularTVShows(params = {}) {
       formattedItem.source = "TMDB热门剧集";
       formattedItem.contentType = "TV剧集";
       return formattedItem;
-    });
+    }).filter(item => item.posterPath); // 新增过滤
   } catch (error) {
     console.error("Error fetching TMDB popular TV shows:", error);
     return [];
@@ -1469,7 +1477,7 @@ async function tmdbTVShowsByTime(params = {}) {
       formattedItem.timePeriod = time_period;
       formattedItem.contentType = "时间榜剧集";
       return formattedItem;
-    });
+    }).filter(item => item.posterPath); // 新增过滤
   } catch (error) {
     console.error("Error fetching TMDB TV shows by time:", error);
     return [];

--- a/tmdb_3.js
+++ b/tmdb_3.js
@@ -535,7 +535,8 @@ async function fetchTmdbData(api, params) {
                 mediaType: mediaType,
                 genreTitle: genreTitle
             };
-        });
+        })
+        .filter(item => item.posterPath); // 新增过滤
 }
 
 async function loadTmdbTrendingData() {
@@ -556,7 +557,7 @@ async function loadTodayGlobalMedia() {
         posterPath: item.poster_url,
         backdropPath: item.title_backdrop,
         mediaType: item.type,
-    }));
+    })).filter(item => item.posterPath); // 新增过滤
 }
 
 async function loadWeekGlobalMovies(params) {
@@ -572,7 +573,7 @@ async function loadWeekGlobalMovies(params) {
         posterPath: item.poster_url,
         backdropPath: item.title_backdrop,
         mediaType: item.type,
-    }));
+    })).filter(item => item.posterPath); // 新增过滤
 }
 
 async function tmdbPopularMovies(params) {
@@ -591,7 +592,7 @@ async function tmdbPopularMovies(params) {
         posterPath: item.poster_url,
         backdropPath: item.title_backdrop,
         mediaType: item.type
-            }));
+            })).filter(item => item.posterPath); // 新增过滤
     }
     
     const [data, genres] = await Promise.all([
@@ -616,7 +617,7 @@ async function tmdbPopularMovies(params) {
         rating: item.vote_average,
         mediaType: "movie",
         genreTitle: getTmdbGenreTitles(item.genre_ids, "movie")
-    }));
+    })).filter(item => item.posterPath); // 新增过滤
 }
 
 async function tmdbTopRated(params) {

--- a/tmdb_list.js
+++ b/tmdb_list.js
@@ -366,7 +366,8 @@ async function fetchTmdbData(api, params) {
                 mediaType: mediaType,
                 genreTitle: genreTitle
             };
-        });
+        })
+        .filter(item => item.posterPath); // 新增过滤
 }
 
 async function loadTmdbTrendingData() {
@@ -387,7 +388,7 @@ async function loadTodayGlobalMedia() {
         posterPath: item.poster_url,
         backdropPath: item.title_backdrop,
         mediaType: item.type,
-    }));
+    })).filter(item => item.posterPath); // 新增过滤
 }
 
 async function loadWeekGlobalMovies(params) {
@@ -403,7 +404,7 @@ async function loadWeekGlobalMovies(params) {
         posterPath: item.poster_url,
         backdropPath: item.title_backdrop,
         mediaType: item.type,
-    }));
+    })).filter(item => item.posterPath); // 新增过滤
 }
 
 async function tmdbPopularMovies(params) {
@@ -422,7 +423,7 @@ async function tmdbPopularMovies(params) {
         posterPath: item.poster_url,
         backdropPath: item.title_backdrop,
         mediaType: item.type
-            }));
+            })).filter(item => item.posterPath); // 新增过滤
     }
     
     const [data, genres] = await Promise.all([
@@ -447,7 +448,7 @@ async function tmdbPopularMovies(params) {
         rating: item.vote_average,
         mediaType: "movie",
         genreTitle: getTmdbGenreTitles(item.genre_ids, "movie")
-    }));
+    })).filter(item => item.posterPath); // 新增过滤
 }
 
 async function tmdbTopRated(params) {


### PR DESCRIPTION
Filter out media items without a poster path to prevent display of incomplete entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-315566f9-f812-46dc-9797-0a3a5459c652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-315566f9-f812-46dc-9797-0a3a5459c652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>